### PR TITLE
Fixed crash if only one label present.

### DIFF
--- a/ios-linechart/LCLineChartView.m
+++ b/ios-linechart/LCLineChartView.m
@@ -201,7 +201,7 @@
     static CGFloat dashedPattern[] = {4,2};
 
     // draw scale and horizontal lines
-    CGFloat heightPerStep = self.ySteps == nil || [self.ySteps count] == 0 ? availableHeight : (availableHeight / ([self.ySteps count] - 1));
+    CGFloat heightPerStep = self.ySteps == nil || [self.ySteps count] <= 1 ? availableHeight : (availableHeight / ([self.ySteps count] - 1));
 
     NSUInteger i = 0;
     CGContextSaveGState(c);


### PR DESCRIPTION
If there's only one label (`[self.ySteps count] == 1`) line 204 would result in a division by 0 which leads to a crash in line 222 (as `heightPerStep == Infinity` and `yStart == NaN`).
