### PR TITLE
Redraw the legend on changing titles/colors

### DIFF
--- a/ios-linechart/LCLegendView.m
+++ b/ios-linechart/LCLegendView.m
@@ -12,6 +12,8 @@
 
 @implementation LCLegendView
 @synthesize titlesFont=_titlesFont;
+@synthesize titles=_titles;
+@synthesize colors=_colors;
 
 #define COLORPADDING 15
 #define PADDING 5
@@ -59,6 +61,30 @@
         w = MAX(w, s.width);
     }
     return CGSizeMake(COLORPADDING + w + 2 * PADDING, h + 2 * PADDING);
+}
+
+- (void)setTitles:(NSArray *)titles {
+    if (titles != _titles) {
+        _titles = titles;
+        [self sizeToFit];
+        [self setNeedsDisplay];
+    }
+}
+
+- (NSArray *)titles {
+    return _titles;
+}
+
+- (void)setColors:(NSDictionary *)colors {
+    if (colors != _colors) {
+        _colors = colors;
+        [self sizeToFit];
+        [self setNeedsDisplay];
+    }
+}
+
+- (NSDictionary *)colors {
+    return _colors;
 }
 
 @end


### PR DESCRIPTION
This was a cause the legend view was empty on creation the chart on iOS 8.x