### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Just copy these into you project as well.
 
 ios-linechart uses Core Graphics, so you'll need to add `CoreGraphics.framework` to your project.
 
-Even if you don't use Cocoapods, it is recommended to use an official release, since the repository may be unstable in  between releases. Just check out the newest tagged commit.
+Even if you don't use CocoaPods, it is recommended to use an official release, since the repository may be unstable in  between releases. Just check out the newest tagged commit.
 
 
 
@@ -111,7 +111,7 @@ The `yMin` and `yMax` properties should be self-evident. `ySteps` is an array of
 
 - *The sample project doesn't compile*
 
-  The sample project, at the moment, needs CocoaPods. Install Cocoapods, then run `pod install` while you are in the ios-linechart directory.
+  The sample project, at the moment, needs CocoaPods. Install CocoaPods, then run `pod install` while you are in the ios-linechart directory.
   
 - *Will the project support bar charts, pie charts, ...?*
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ The `yMin` and `yMax` properties should be self-evident. `ySteps` is an array of
 - *The sample project doesn't compile*
 
   The sample project, at the moment, needs CocoaPods. Install CocoaPods, then run `pod install` while you are in the ios-linechart directory.
-  
-- *Will the project support bar charts, pie charts, ...?*
+	
+## Support this project
 
-  No.
+[![Support via Gittip](https://rawgithub.com/twolfson/gittip-badge/0.2.0/dist/gittip.png)](https://www.gittip.com/mruegenberg/)
 
 ## Contact
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
